### PR TITLE
Fixed 4 issues of type: PYTHON_E225 throughout 2 files in repo.

### DIFF
--- a/pyturochamp.py
+++ b/pyturochamp.py
@@ -144,7 +144,7 @@ def getval1(b):
 	+	3 * (len(b.pieces(c.KNIGHT, c.WHITE))   - len(b.pieces(c.KNIGHT, c.BLACK)))
 	+	3.5 * (len(b.pieces(c.BISHOP, c.WHITE)) - len(b.pieces(c.BISHOP, c.BLACK)))
 	+	5 * (len(b.pieces(c.ROOK, c.WHITE))     - len(b.pieces(c.ROOK, c.BLACK)))
-	+	10* (len(b.pieces(c.QUEEN, c.WHITE))    - len(b.pieces(c.QUEEN, c.BLACK)))
+	+	10 * (len(b.pieces(c.QUEEN, c.WHITE))    - len(b.pieces(c.QUEEN, c.BLACK)))
 	)
 
 def getval2(b):
@@ -154,14 +154,14 @@ def getval2(b):
 	+	3 * len(b.pieces(c.KNIGHT, c.WHITE))
 	+	3.5 * len(b.pieces(c.BISHOP, c.WHITE))
 	+	5 * len(b.pieces(c.ROOK, c.WHITE))
-	+	10* len(b.pieces(c.QUEEN, c.WHITE))
+	+	10 * len(b.pieces(c.QUEEN, c.WHITE))
 	)
 	bv = (
 		len(b.pieces(c.PAWN, c.BLACK))
 	+	3 * len(b.pieces(c.KNIGHT, c.BLACK))
 	+	3.5 * len(b.pieces(c.BISHOP, c.BLACK))
 	+	5 * len(b.pieces(c.ROOK, c.BLACK))
-	+	10* len(b.pieces(c.QUEEN, c.BLACK))
+	+	10 * len(b.pieces(c.QUEEN, c.BLACK))
 	)
 	return wv / bv
 

--- a/rmove.py
+++ b/rmove.py
@@ -19,7 +19,7 @@ def getval(b):
 	+	3 * (len(b.pieces(c.KNIGHT, c.WHITE))   - len(b.pieces(c.KNIGHT, c.BLACK)))
 	+	3.5 * (len(b.pieces(c.BISHOP, c.WHITE)) - len(b.pieces(c.BISHOP, c.BLACK)))
 	+	5 * (len(b.pieces(c.ROOK, c.WHITE))     - len(b.pieces(c.ROOK, c.BLACK)))
-	+	10* (len(b.pieces(c.QUEEN, c.WHITE))    - len(b.pieces(c.QUEEN, c.BLACK)))
+	+	10 * (len(b.pieces(c.QUEEN, c.WHITE))    - len(b.pieces(c.QUEEN, c.BLACK)))
 	)
 
 def pm():


### PR DESCRIPTION
PYTHON_E225: 'Fix extraneous whitespace around keywords.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.